### PR TITLE
Upgrade puma gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 6.0.3', '>= 6.0.3.1'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server
-gem 'puma', '~> 4.1'
+gem 'puma', '~> 4.3'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       method_source (>= 0.6.5)
       ruby_parser (>= 2.0.5)
       slop (~> 2.1.0)
-    puma (4.3.5)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.2)
     rack-cors (1.1.1)
@@ -239,4 +239,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.3
+   2.1.4


### PR DESCRIPTION
Explain why this change is being made.
---
- The 4.3.5 version of puma has a bug that avoids to runs it in on OS versions newer than Mojave

More info: https://thoughtfulapps.com/articles/rails/puma-implicitly-declaring-library-function-error

Explain how this is accomplished.
---

- Simply upgrade the puma version from 4.3.5 to 4.3.6

Merge/Deploy Checklist
----

- [ ] It has been reviewed for code quality.
- [ ] It has been visually reviewed and accepted.

How do you manually test this?
----

Running `rails server` command on MacBooks with Catalina or newer OS

Screenshots
----

| Desktop | Mobile |
|--|--|
N/A
| image_placeholder | image_placeholder |
N/A